### PR TITLE
Upgrade style-dictionary to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["20"]
+        node: ["22"]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3

--- a/build.js
+++ b/build.js
@@ -60,7 +60,8 @@ function darkFormatWrapper(format) {
 
     // Use the built-in format but with our customized dictionary object
     // so it will output the darkValue instead of the value
-    return StyleDictionary.format[format]({ ...args, dictionary });
+    const formats = StyleDictionary.format || StyleDictionary.formats;
+    return formats[format]({ ...args, dictionary });
   };
 }
 

--- a/formats/utilityClass/utilityClass.js
+++ b/formats/utilityClass/utilityClass.js
@@ -168,7 +168,8 @@ const utilityClass = {
   name: 'css/utility-classes',
   formatter: function (dictionary) {
     let output = createFileHeader();
-    const breakpoints = dictionary.allProperties.filter(
+    const allTokens = dictionary.allTokens || dictionary.allProperties || [];
+    const breakpoints = allTokens.filter(
       prop => prop.attributes.type === 'breakpoint',
     );
     /**
@@ -190,7 +191,7 @@ const utilityClass = {
      * to CSS hierarchy of border and border-color properties. In order for border-color to successfully
      * override border it has to be declared after border.
      */
-    dictionary.allProperties.forEach(prop => {
+    allTokens.forEach(prop => {
       output += processUtilities(utilities, prop);
 
       /**
@@ -220,7 +221,7 @@ const utilityClass = {
         utility => utility.focus,
       );
 
-      dictionary.allProperties.forEach(prop => {
+      allTokens.forEach(prop => {
         responsiveUtilityClasses += processUtilities(
           responsiveUtilities,
           prop,
@@ -231,7 +232,7 @@ const utilityClass = {
         );
       });
 
-      dictionary.allProperties.forEach(prop => {
+      allTokens.forEach(prop => {
         responsiveUtilityClasses += processUtilities(
           responsiveAndHoverUtilities,
           prop,
@@ -243,7 +244,7 @@ const utilityClass = {
         );
       });
 
-      dictionary.allProperties.forEach(prop => {
+      allTokens.forEach(prop => {
         responsiveUtilityClasses += processUtilities(
           responsiveAndFocusUtilities,
           prop,

--- a/formats/utilityClass/utilityClass.test.js
+++ b/formats/utilityClass/utilityClass.test.js
@@ -1,7 +1,7 @@
 const utilityClass = require('./utilityClass');
 
 const mockDictionary = {
-  allProperties: [
+  allTokens: [
     {
       value: '#f3f4f6',
       darkValue: '#1f2937',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "semantic-release": "^22.0.12",
-    "style-dictionary": "^3.9.2"
+    "style-dictionary": "^4.3.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Bring the repository up to the latest Style Dictionary major (v4) to stay current and compatible with the v4 dictionary shape and API.
- Make the dark-mode format wrapper resilient to the registry location change introduced in newer Style Dictionary versions.
- Ensure utility class formatter and tests work with the v4 dictionary structure (`allTokens`).

### Description
- Bumped `style-dictionary` devDependency from `^3.9.2` to `^4.3.0` in `package.json`.
- Updated the dark format wrapper in `build.js` to use `StyleDictionary.format || StyleDictionary.formats` when invoking built-in formats.
- Modified `formats/utilityClass/utilityClass.js` to iterate `dictionary.allTokens` with a fallback to `allProperties` and to derive breakpoints from that list.
- Updated the unit test mock in `formats/utilityClass/utilityClass.test.js` to provide `allTokens` instead of `allProperties` to match the v4 dictionary shape.

### Testing
- Ran `pnpm test` and all test suites passed (5 test suites, 18 tests).
- Ran `pnpm build` and the style-dictionary build completed successfully and generated the expected output files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ebadd6188326ad7567e35f4e89bc)