### PR TITLE
fix: rename badge-destructive to badge-danger

### DIFF
--- a/tokens/color/background.json
+++ b/tokens/color/background.json
@@ -102,7 +102,7 @@
         "value": "{color.base.grey.100.value}",
         "darkValue": "{color.base.grey.700.value}"
       },
-      "badge-destructive": {
+      "badge-danger": {
         "value": "{color.base.red.50.value}",
         "darkValue": "{color.base.red.900.value}"
       },

--- a/tokens/color/border.json
+++ b/tokens/color/border.json
@@ -85,7 +85,7 @@
         "value": "{color.base.grey.100.value}",
         "darkValue": "{color.base.grey.700.value}"
       },
-      "badge-destructive": {
+      "badge-danger": {
         "value": "{color.base.red.100.value}",
         "darkValue": "{color.base.red.800.value}"
       },

--- a/tokens/color/font.json
+++ b/tokens/color/font.json
@@ -114,7 +114,7 @@
         "value": "{color.base.grey.700.value}",
         "darkValue": "{color.base.grey.100.value}"
       },
-      "badge-destructive": {
+      "badge-danger": {
         "value": "{color.base.red.600.value}",
         "darkValue": "{color.base.red.400.value}"
       },


### PR DESCRIPTION
Rename the color token key "badge-destructive" to "badge-danger" across color tokens (background.json, border.json, font.json). Token values and darkValue variants are unchanged; this standardizes the badge naming in the design system.